### PR TITLE
feat: add file compression with zstd

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,1 +1,46 @@
+use crate::CompressMessage;
+use std::io::{Read, Write};
+use std::sync::mpsc;
 
+pub fn start_compression(
+    input_path: String,
+    output_path: String,
+    tx: mpsc::Sender<CompressMessage>,
+) {
+    std::thread::spawn(move || {
+        let run = || -> std::io::Result<()> {
+            let mut input_file = std::fs::File::open(&input_path)?;
+            let total_bytes = input_file.metadata()?.len();
+            let output_file = std::fs::File::create(&output_path)?;
+
+            let mut encoder = zstd::stream::Encoder::new(output_file, 3)?;
+            let mut buffer = [0u8; 64 * 1024]; // 64KB buffer
+            let mut bytes_processed: u64 = 0;
+
+            loop {
+                let bytes_read = input_file.read(&mut buffer)?;
+                if bytes_read == 0 {
+                    break;
+                }
+                encoder.write_all(&buffer[..bytes_read])?;
+                bytes_processed += bytes_read as u64;
+                let _ = tx.send(CompressMessage::Progress {
+                    bytes_processed,
+                    total_bytes,
+                });
+            }
+
+            encoder.finish()?;
+            Ok(())
+        };
+
+        match run() {
+            Ok(_) => {
+                let _ = tx.send(CompressMessage::Finished);
+            }
+            Err(e) => {
+                let _ = tx.send(CompressMessage::Error(e.to_string()));
+            }
+        }
+    });
+}


### PR DESCRIPTION
 Closes #1

  ## What?
  Adds the actual compression feature to Freya. Before this, the app could open a file picker but didn't do
  anything with the selected file. Now it compresses the file using zstd and saves it as a `.zst` file.

  ## Some Details
  - **`compression.rs`** : Was empty. Now has the compression logic that reads a file, compresses it, and
  reports progress back to the UI
  - **`app.rs`** : Connected the compression to the file picker, and fixed the event loop so the UI stays
  responsive while a file is being compressed

  ## Test 
  1. `cargo run`
  2. Press `o` and pick a file
  3. Watch the status update to "Compression complete!"
  4. You'll see a new `.zst` file next to the original (e.g. `photo.png.zst`)