### PR TITLE
feat: add save to custom location

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ pub mod ui;
 
 pub use app::*;
 pub use compression::*;
-pub use ui::*;
 
 pub enum CompressMessage {
     Progress {


### PR DESCRIPTION
Closes __#4__

## What?
Adds a "Save To" option so the user can choose where the compressed `.zst` file is saved. Before this, the output was always written next to the original file with no way to change it. Now pressing `s` opens a native save dialog pre-filled with the suggested filename, and the user can navigate to any folder before compression starts.

## Some Details
* `app.rs` : Added the `'s'` keybinding which opens a file picker (to choose the input) followed by a save dialog (to choose the output location). Pre-fills the save dialog with the suggested `.zst` filename so the user only needs to pick a folder. Falls back to saving beside the original if the save dialog is cancelled. Extracted `default_output_path()` and `start_compression_job()` helpers to avoid duplicating path-building and channel setup logic between `'o'` and `'s'`

## Test
1. `cargo run`
2. Press `s` and pick a file
3. In the save dialog, navigate to a different folder and confirm
4. Compression runs and the `.zst` file appears in the chosen location
5. Press `s` again, pick a file, then **cancel** the save dialog — compression should still run and save the `.zst` next to the original as a fallback